### PR TITLE
Fixing Properties bug

### DIFF
--- a/src/Log4net.Appenders.Fluentd/FluentdAppender.cs
+++ b/src/Log4net.Appenders.Fluentd/FluentdAppender.cs
@@ -96,7 +96,7 @@ namespace Log4net.Appenders.Fluentd
                 foreach (var key in loggingEvent.Properties.GetKeys())
                 {
                     var val = loggingEvent.Properties[key];
-                    if (val != null)
+                    if (val == null)
                         continue;
 
                     record[key] = SerializePropertyValue(key, val);


### PR DESCRIPTION
For logging properties to work, this check needs to be reversed.  Probably a typo.

Have verified that this change works; it was needed to get properties working.